### PR TITLE
fix NAT traversal for Nodes behind NAT by exposing coturn on 3478

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,6 +32,11 @@ services:
     restart: on-failure
     volumes:
       - ./coturn/turnserver.conf:/etc/coturn/turnserver.conf
+    ports:
+      - '3478:3478'
+      - '3478:3478/udp'
+      - '49160-59200:49160-59200/udp'
+    network_mode: host
 
 volumes:
   evio-mysql: {}


### PR DESCRIPTION
Before exposing port of coturn on 3478 For Nodes behind the NAT
are not able to ping other nodes and vice-versa as they depend and connect
coturn on Public_IP:3478


Signed-off-by: Pratik raj <rajpratik71@gmail.com>